### PR TITLE
add inventory_file option

### DIFF
--- a/lib/vagrant-ansible/provisioner.rb
+++ b/lib/vagrant-ansible/provisioner.rb
@@ -9,9 +9,10 @@ module Vagrant
       class Config < Vagrant::Config::Base
         attr_accessor :playbook
         attr_accessor :hosts
+        attr_accessor :inventory_file
 
         def initialize
-          
+
         end
 
         def validate(env, errors)
@@ -19,7 +20,7 @@ module Vagrant
           if playbook.nil?
             errors.add(I18n.t("vagrant.provisioners.ansible.no_playbook"))
           end
-          if hosts.nil?
+          if hosts.nil? and inventory_file.nil?
             errors.add(I18n.t("vagrant.provisioners.ansible.no_hosts"))
           end
         end
@@ -32,33 +33,37 @@ module Vagrant
       # This methods yield the path to a temporally created inventory
       # file.
       def with_inventory_file(ssh)
-        begin
-          forward = env[:vm].config.vm.forwarded_ports.select do |x| 
-            x[:guestport] == ssh.guest_port
-          end.first[:hostport]
-          file = Tempfile.new('inventory')
-          file.write("[#{config.hosts}]\n")
-          file.write("#{ssh.host}:#{forward}")
-          file.fsync
-          file.close
-          yield file.path
-        ensure
-          file.unlink
+        if not config.inventory_file.nil?
+          yield config.inventory_file
+        else
+          begin
+            forward = env[:vm].config.vm.forwarded_ports.select do |x|
+              x[:guestport] == ssh.guest_port
+            end.first[:hostport]
+            file = Tempfile.new('inventory')
+            file.write("[#{config.hosts}]\n")
+            file.write("#{ssh.host}:#{forward}")
+            file.fsync
+            file.close
+            yield file.path
+          ensure
+            file.unlink
+          end
         end
       end
 
       def provision!
         ssh = env[:vm].config.ssh
- 
+
         with_inventory_file(ssh) do |inventory_file|
           puts ["ansible-playbook",
-                    "--user=#{ssh.username}", 
-                    "--inventory-file=#{inventory_file}", 
+                    "--user=#{ssh.username}",
+                    "--inventory-file=#{inventory_file}",
                     "--private-key=#{env[:vm].env.default_private_key_path}",
                     config.playbook].join(' ')
           safe_exec("ansible-playbook",
-                    "--user=#{ssh.username}", 
-                    "--inventory-file=#{inventory_file}", 
+                    "--user=#{ssh.username}",
+                    "--inventory-file=#{inventory_file}",
                     "--private-key=#{env[:vm].env.default_private_key_path}",
                     config.playbook)
         end

--- a/spec/vagrant-ansible/provisioner_spec.rb
+++ b/spec/vagrant-ansible/provisioner_spec.rb
@@ -14,18 +14,18 @@ class Hash
 end
 
 describe "Provisioner" do
-  
+
   let(:e) { Vagrant::Config::ErrorRecorder.new }
-  let(:config) { 
+  let(:config) {
     c = Vagrant::Provisioners::Ansible::Config.new
     c.playbook = "playbook"
     c.hosts    = "hosts"
     c
   }
-  let(:env) { 
-    {:vm  => 
-      {:config => 
-        {:vm => 
+  let(:env) {
+    {:vm  =>
+      {:config =>
+        {:vm =>
           {:forwarded_ports => [{:guestport => 2222, :hostport => 22}]},
          :ssh => {:host => "localhost", :guest_port => 2222, :username => 'sshuser'}
         },
@@ -59,11 +59,22 @@ describe "Provisioner" do
   it "should call ansible-playboot with the right arguments" do
     Tempfile.stub(:new).and_return(filemock)
     provisioner.should_receive(:safe_exec).with(
-          "ansible-playbook", 
-          "--user=sshuser", 
-          "--inventory-file=path", 
-          "--private-key=private_key_path", 
+          "ansible-playbook",
+          "--user=sshuser",
+          "--inventory-file=path",
+          "--private-key=private_key_path",
           "playbook")
+    provisioner.provision!
+  end
+
+  it "should call ansible-playboot with the given inventory file" do
+    config.inventory_file = "/tmp/ansible_hosts"
+    provisioner.should_receive(:safe_exec).with(
+      "ansible-playbook",
+      "--user=sshuser",
+      "--inventory-file=/tmp/ansible_hosts",
+      "--private-key=private_key_path",
+      "playbook")
     provisioner.provision!
   end
 end


### PR DESCRIPTION
I needed to manage ansible groups and hosts manually in a separated inventory file so I have added an option to specify this file in vagrant ansible provisioner.
