### PR TITLE
use {ssh.port} in creating inventory file

### DIFF
--- a/lib/vagrant-ansible/provisioner.rb
+++ b/lib/vagrant-ansible/provisioner.rb
@@ -52,12 +52,9 @@ module Vagrant
           yield config.inventory_file
         else
           begin
-            forward = env[:vm].config.vm.forwarded_ports.select do |x|
-              x[:guestport] == ssh.guest_port
-            end.first[:hostport]
             file = Tempfile.new('inventory')
             file.write("[#{config.hosts}]\n")
-            file.write("#{ssh.host}:#{forward}")
+            file.write("#{ssh.host}:#{ssh.port}")
             file.fsync
             file.close
             yield file.path


### PR DESCRIPTION
I need known ssh ports for each VM, when I create more then one VM on my guest.

In Vagrant::config.run I define:

``` ruby
    config.ssh.port = 3330
    config.vm.forward_port  22, 3330
```

The inventory file now lists:

```
[web-servers]
127.0.0.1:2222
```

I am not sure if this will create problems in other configurations.
