### PR TITLE
Support multiple host names

### DIFF
--- a/lib/vagrant-ansible/provisioner.rb
+++ b/lib/vagrant-ansible/provisioner.rb
@@ -55,9 +55,15 @@ module Vagrant
             forward = env[:vm].config.vm.forwarded_ports.select do |x|
               x[:guestport] == ssh.guest_port
             end.first[:hostport]
+            if not config.hosts.kind_of?(Array)
+              config.hosts = [config.hosts]
+            end
             file = Tempfile.new('inventory')
-            file.write("[#{config.hosts}]\n")
-            file.write("#{ssh.host}:#{forward}")
+            config.hosts.each do |host|
+              file.write("[#{host}]\n")
+              file.write("#{ssh.host}:#{forward}\n")
+              file.write("\n")
+            end
             file.fsync
             file.close
             yield file.path

--- a/spec/vagrant-ansible/config_spec.rb
+++ b/spec/vagrant-ansible/config_spec.rb
@@ -17,5 +17,12 @@ describe "Config" do
       config.validate({}, e)
       e.errors.length.should == 0
     end
+
+    it "should not add any errors if the hosts is an array" do
+      config.playbook = "test"
+      config.hosts    = ["webservers", "databases"]
+      config.validate({}, e)
+      e.errors.length.should == 0
+    end
   end
 end


### PR DESCRIPTION
Some of my playbooks belong to different ansible hosts and I would like to install them all using vagrant-ansible.

This pull request lets you specify `ansible.hosts = ["host1", "host2"]` in the Vagrantfile, which generates an inventory file looking something like:

```
[host1]
localhost:22

[host2]
locahost:22

```

Single host syntax (`ansible.hosts = "host1"`) is still supported.

I rarely write Ruby code, so please let me know if you need anything changed.
