### PR TITLE
Forcing ssh username in temporary hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,6 @@ Now change into the ansible-playbooks directory and download the example Vagrant
     cd ansible-playbooks
     wget https://raw.github.com/dsander/vagrant-ansible/master/Vagrantfile.sample -O Vagrantfile
     
-Before you can run your playbook for the first time, you have to change the remote user to 'vagrant' in your playbook. This is necessary because the user specified in the playbook can not be overridden via command line options.
-
-    ....
-    - hosts: web-servers
-      user: vagrant
-    .....
-
-
 Create a 32-bit Ubuntu virtual machine you will be developing playbooks in:
 
     vagrant up 

--- a/lib/vagrant-ansible/provisioner.rb
+++ b/lib/vagrant-ansible/provisioner.rb
@@ -61,7 +61,7 @@ module Vagrant
             file = Tempfile.new('inventory')
             config.hosts.each do |host|
               file.write("[#{host}]\n")
-              file.write("#{ssh.host}:#{forward}\n")
+              file.write("#{ssh.host}:#{forward} ansible_ssh_user=#{ssh.username}\n")
               file.write("\n")
             end
             file.fsync


### PR DESCRIPTION
You are able to force the vagrant username in the temporary hosts file instead of having to override the value in the playbook.
