### PR TITLE
Support for setting extra-vars from hash (ansible.extra_vars)

### DIFF
--- a/lib/vagrant-ansible/provisioner.rb
+++ b/lib/vagrant-ansible/provisioner.rb
@@ -12,6 +12,7 @@ module Vagrant
         attr_accessor :inventory_file
         attr_accessor :ask_sudo_pass
         attr_accessor :sudo
+        attr_accessor :extra_vars
 
         def initialize
           @options = []
@@ -83,6 +84,7 @@ module Vagrant
 
           options << "--ask-sudo-pass" if config.ask_sudo_pass
           options << "--sudo" if config.sudo
+          options << "--extra-vars=" + config.extra_vars.map{|k,v| "#{k}=#{v}"}.join(' ') if config.extra_vars
           options = options + config.options unless config.options.empty?
 
           cmd = (%w(ansible-playbook) << options << config.playbook).flatten


### PR DESCRIPTION
Added a new attribute ansible.extra_vars, which supports setting Ansible's extra-vars parameter via a Ruby hash.

This allows you to have this in your Vagrantfile:

```
  ansible.extra_vars = {
    hosts: server1_config.vm.host_name,
    hostname: server1_hostname,
    cookie_domain: cookie_domain,
    deployment_uri: deployment_uri,
    root_suffix: root_suffix,
  }
```

Which is more maintainable than cramming everything in the ansible.options attribute.
